### PR TITLE
feat: incremental polling — show fast assessments while slow ones run

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useTheme } from './hooks/useTheme';
 import { useScan } from './hooks/useScan';
 import { ScanForm } from './components/ScanForm';
 import { ScanProgress } from './components/ScanProgress';
+import { ScanProgressBanner } from './components/ScanProgressBanner';
 import { ScanResults } from './components/ScanResults';
 import { AboutModal } from './components/AboutModal';
 
@@ -13,8 +14,13 @@ export default function App() {
   const { scan, isLoading, error, submit } = useScan();
   const [showAbout, setShowAbout] = useState(false);
 
-  const showResults = scan !== null && TERMINAL_STATUSES.includes(scan.status);
-  const showProgress = scan !== null && !showResults;
+  const isTerminal     = scan !== null && TERMINAL_STATUSES.includes(scan.status);
+  const isScanning     = scan !== null && !isTerminal;
+  const hasAssessments = scan !== null && scan.assessments.length > 0;
+
+  const showFullProgress = isScanning && !hasAssessments;
+  const showInlineBanner = isScanning && hasAssessments;
+  const showResults      = hasAssessments;
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-white flex flex-col relative overflow-hidden transition-colors duration-300">
@@ -76,7 +82,7 @@ export default function App() {
 
         <ScanForm onSubmit={submit} isLoading={isLoading} />
 
-        {showProgress && <ScanProgress scan={scan} />}
+        {showFullProgress && <ScanProgress scan={scan!} />}
 
         {error && (
           <p role="alert" className="text-sm text-red-500 dark:text-red-400">
@@ -84,7 +90,12 @@ export default function App() {
           </p>
         )}
 
-        {showResults && <ScanResults scan={scan} />}
+        {showResults && (
+          <>
+            {showInlineBanner && <ScanProgressBanner />}
+            <ScanResults scan={scan!} isScanning={isScanning} />
+          </>
+        )}
       </main>
 
       {showAbout && <AboutModal onClose={() => setShowAbout(false)} />}

--- a/src/api/scanner.ts
+++ b/src/api/scanner.ts
@@ -15,11 +15,12 @@ export async function createScan(url: string): Promise<Scan> {
   }
 
   const { data } = await response.json();
+  data.assessments ??= [];
   return data;
 }
 
-export async function getScan(id: string): Promise<Scan> {
-  const response = await fetch(`${BASE_URL}/scans/${id}`, {
+export async function getScan(monitorUrl: string): Promise<Scan> {
+  const response = await fetch(monitorUrl, {
     headers: { Accept: 'application/json' },
   });
 

--- a/src/components/ScanProgressBanner.tsx
+++ b/src/components/ScanProgressBanner.tsx
@@ -1,0 +1,15 @@
+export function ScanProgressBanner() {
+  return (
+    <div role="status" aria-live="polite" className="w-full max-w-4xl">
+      <div className="rounded-xl border border-indigo-200/50 dark:border-indigo-500/20
+                      bg-indigo-50/50 dark:bg-indigo-500/10 px-4 py-3 space-y-2">
+        <p className="text-sm font-medium text-indigo-700 dark:text-indigo-300">
+          Scanning — more checks in progress…
+        </p>
+        <div className="h-1 w-full rounded-full bg-indigo-200 dark:bg-indigo-800 overflow-hidden">
+          <div className="h-full w-full rounded-full bg-indigo-500 animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ScanResults.tsx
+++ b/src/components/ScanResults.tsx
@@ -4,6 +4,7 @@ import { ScoreRing } from './ScoreRing';
 
 interface ScanResultsProps {
   scan: Scan;
+  isScanning?: boolean;
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -106,7 +107,23 @@ function FindingsSection({ name, assessments }: { name: string; assessments: Ass
   );
 }
 
-export function ScanResults({ scan }: ScanResultsProps) {
+function SkeletonCard() {
+  return (
+    <article
+      aria-hidden="true"
+      className="rounded-2xl border border-gray-200 dark:border-white/10
+                 bg-white dark:bg-white/5 p-5 flex items-center gap-4 animate-pulse"
+    >
+      <div className="w-[88px] h-[88px] rounded-full bg-gray-200 dark:bg-white/10 shrink-0" />
+      <div className="space-y-2 flex-1">
+        <div className="h-4 w-24 rounded bg-gray-200 dark:bg-white/10" />
+        <div className="h-3 w-16 rounded bg-gray-100 dark:bg-white/5" />
+      </div>
+    </article>
+  );
+}
+
+export function ScanResults({ scan, isScanning = false }: ScanResultsProps) {
   const categoryMap = new Map<string, typeof scan.assessments>();
   for (const a of scan.assessments) {
     const key = a.category ?? '__other__';
@@ -140,11 +157,13 @@ export function ScanResults({ scan }: ScanResultsProps) {
             Overall Score
           </p>
           <p className="text-gray-600 dark:text-gray-300 text-sm">
-            {overallScore >= 90
-              ? 'Excellent — this site is in great shape.'
-              : overallScore >= 50
-                ? 'Some issues found — there is room for improvement.'
-                : 'Critical issues detected — action recommended.'}
+            {isScanning
+              ? 'Scan in progress — results updating…'
+              : overallScore >= 90
+                ? 'Excellent — this site is in great shape.'
+                : overallScore >= 50
+                  ? 'Some issues found — there is room for improvement.'
+                  : 'Critical issues detected — action recommended.'}
           </p>
         </div>
       </div>
@@ -153,13 +172,20 @@ export function ScanResults({ scan }: ScanResultsProps) {
       {allCategories.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           {allCategories.map(([catId, assessments]) => (
-            <CategoryCard
-              key={catId}
-              id={catId}
-              name={catId === '__other__' ? 'Other' : (CATEGORY_LABELS[catId] ?? formatLabel(catId))}
-              assessments={assessments}
-            />
+            <div key={catId} className="card-enter">
+              <CategoryCard
+                id={catId}
+                name={catId === '__other__' ? 'Other' : (CATEGORY_LABELS[catId] ?? formatLabel(catId))}
+                assessments={assessments}
+              />
+            </div>
           ))}
+          {isScanning && (
+            <>
+              <SkeletonCard />
+              <SkeletonCard />
+            </>
+          )}
         </div>
       )}
 

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -28,10 +28,10 @@ export function useScan(): UseScanResult {
 
   useEffect(() => stopPolling, [stopPolling]);
 
-  const poll = useCallback((id: string) => {
+  const poll = useCallback((monitorUrl: string) => {
     pollRef.current = setInterval(async () => {
       try {
-        const updated = await getScan(id);
+        const updated = await getScan(monitorUrl);
         setScan(updated);
 
         if (TERMINAL_STATUSES.includes(updated.status)) {
@@ -55,7 +55,7 @@ export function useScan(): UseScanResult {
     try {
       const created = await createScan(url);
       setScan(created);
-      poll(created.id);
+      poll(created.monitor);
     } catch (err) {
       setIsLoading(false);
       setError(err instanceof Error ? err.message : 'Something went wrong.');

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,9 @@
 
 .modal-backdrop { animation: modal-backdrop-in 0.15s ease-out forwards; }
 .modal-panel    { animation: modal-panel-in 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+
+@keyframes card-enter {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.card-enter { animation: card-enter 0.35s cubic-bezier(0.16, 1, 0.3, 1) forwards; }

--- a/src/types/scanner.ts
+++ b/src/types/scanner.ts
@@ -26,6 +26,7 @@ export interface Assessment {
 
 export interface Scan {
   id: string;
+  monitor: string;
   url: string;
   status: ScanStatus;
   details: Record<string, unknown> | null;


### PR DESCRIPTION
## Summary

- Poll the monitor URL every 2 s instead of a fixed scan ID endpoint
- Render each assessment card as it lands rather than waiting for the full scan to complete
- Show a slim animated `ScanProgressBanner` once the first result arrives so the user knows more checks are still running
- Stop polling only when the scan reaches a terminal status (`completed`, `completed_with_errors`, `failed`)

## Changes

- `src/hooks/useScan.ts` — switch from ID-based polling to monitor-URL polling; stop only on terminal status
- `src/api/scanner.ts` — `getScan()` now accepts a full monitor URL instead of an ID
- `src/App.tsx` — incremental rendering: full progress → inline banner + partial results → all results
- `src/components/ScanProgressBanner.tsx` — new slim animated banner shown while scan is still running but partial results exist
- `src/components/ScanResults.tsx`, `src/types/scanner.ts`, `src/index.css` — supporting tweaks

## Test plan

- [ ] Submit a scan; fast checks (green-hosting, http-fetch) appear within ~1-2 polls
- [ ] Animated banner is visible while Lighthouse is still running
- [ ] Banner disappears and Lighthouse card appears once the slow check completes
- [ ] Polling stops after final status is received; no further network requests