### PR TITLE
fix: point VITE_API_URL at the deployed backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - run: npm run build
         env:
           BASE_PATH: /wrs-frontend/
-          VITE_API_URL: /api
+          VITE_API_URL: https://api.wrs.cloudfest.dev/api
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

- `VITE_API_URL` was `/api` (relative path — only works when frontend is served by the Laravel app itself)
- Changed to `https://api.wrs.cloudfest.dev/api` so the GitHub Pages build talks to the deployed backend

## Test plan

- [ ] Deploy workflow builds with correct API URL
- [ ] Frontend at https://cfhack2026-wrs.github.io/wrs-frontend/ can submit scans and receive results