### PR TITLE
fix: deduplicate findings and normalize scores across assessments

### DIFF
--- a/src/components/ChecklistView.tsx
+++ b/src/components/ChecklistView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Assessment } from '../types/scanner';
+import { mergeFindings } from '../utils/findings';
 
 interface ChecklistViewProps {
   assessments: Assessment[];
@@ -18,18 +19,11 @@ function groupByCategory(assessments: Assessment[]): Map<string, Assessment[]> {
 
 const CATEGORY_META: Record<string, { label: string; icon: string; color: string; bg: string; desc: string }> = {
   accessibility: {
-    label: 'Accessibility (Lighthouse)',
+    label: 'Accessibility',
     icon: '♿',
     color: 'var(--eaa-purple)',
     bg: 'var(--eaa-purple-bg)',
-    desc: 'Automated checks via Google Lighthouse — covers ARIA, colour contrast, focus management, heading order and more.',
-  },
-  axe: {
-    label: 'Accessibility (Axe)',
-    icon: '🔍',
-    color: 'var(--eaa-accent)',
-    bg: 'var(--eaa-accent-bg)',
-    desc: 'In-depth accessibility audit using axe-core — reports WCAG 2.x A/AA violations with affected HTML elements.',
+    desc: 'Automated checks via axe-core and Google Lighthouse — covers ARIA, colour contrast, focus management, heading order and more.',
   },
   sustainability: {
     label: 'Sustainability',
@@ -82,7 +76,6 @@ function extractWcagTags(tags: string[]): string[] {
   return tags
     .filter((t) => /^wcag\d/.test(t))
     .map((t) => {
-      // "wcag143" → "WCAG 1.4.3"
       const digits = t.replace(/^wcag/i, '');
       const formatted = digits.replace(/(\d)(?=(\d{1,2})$)/, '$1.').replace(/(\d)(?=(\d)$)/, '$1.');
       return `WCAG ${formatted}`;
@@ -239,39 +232,46 @@ function FindingItem({ finding, defaultOpen = false }: FindingItemProps) {
   );
 }
 
-function categoryScore(assessments: Assessment[]): { passed: number; failed: number; total: number; pct: number } {
-  const relevant = assessments.filter((a) => a.status !== 'skipped');
-  const passed = relevant.filter((a) => a.findings.length === 0 && a.status === 'completed').length;
-  const failed = relevant.filter((a) => a.findings.length > 0).length;
-  const total = relevant.length;
-  const pct = total > 0 ? Math.round((passed / total) * 100) : 100;
-  return { passed, failed, total, pct };
+/** Averages score_percent across all completed assessments that provide one. */
+function normalizedCategoryScore(assessments: Assessment[]): number | undefined {
+  const scores = assessments
+    .filter((a) => a.status === 'completed' && typeof a.details?.score_percent === 'number')
+    .map((a) => a.details!.score_percent as number);
+  if (scores.length === 0) return undefined;
+  return Math.round(scores.reduce((s, n) => s + n, 0) / scores.length);
 }
 
-function AssessmentPanel({ assessment, meta, showHeader = true }: { assessment: Assessment; meta: ReturnType<typeof fallbackMeta>; showHeader?: boolean }) {
-  const { passed, total, pct } = categoryScore([assessment]);
-  const allFindings = assessment.findings;
+/** Builds a "Axe: 84% · Lighthouse: 82%" sub-label when multiple scores exist. */
+function scoreSubLabel(assessments: Assessment[]): string | undefined {
+  const parts = assessments
+    .filter((a) => a.status === 'completed' && typeof a.details?.score_percent === 'number')
+    .map((a) => {
+      const label = a.identifier.charAt(0).toUpperCase() + a.identifier.slice(1);
+      return `${label}: ${a.details!.score_percent as number}%`;
+    });
+  return parts.length > 1 ? parts.join(' · ') : undefined;
+}
 
-  // Lighthouse: details has score_percent
-  const lighthouseScore =
-    typeof assessment.details?.score_percent === 'number'
-      ? assessment.details.score_percent
-      : undefined;
+function CategoryPanel({ assessments, meta }: { assessments: Assessment[]; meta: ReturnType<typeof fallbackMeta> }) {
+  const mergedFindings = mergeFindings(assessments);
+  const score = normalizedCategoryScore(assessments);
+  const subLabel = scoreSubLabel(assessments);
 
-  // Axe: details has passes_count, violations_count
-  const axePasses =
-    typeof assessment.details?.passes_count === 'number'
-      ? assessment.details.passes_count
-      : undefined;
-  const axeViolations =
-    typeof assessment.details?.violations_count === 'number'
-      ? assessment.details.violations_count
-      : undefined;
+  // Axe-specific stats (passes/violations) from the axe assessment if present
+  const axeAssessment = assessments.find((a) => a.identifier === 'axe');
+  const axePasses = typeof axeAssessment?.details?.passes_count === 'number'
+    ? axeAssessment.details.passes_count as number
+    : undefined;
+  const axeViolations = typeof axeAssessment?.details?.violations_count === 'number'
+    ? axeAssessment.details.violations_count as number
+    : undefined;
+
+  const allCompleted = assessments.every((a) => a.status === 'completed');
 
   return (
     <div>
       {/* Category header */}
-      {showHeader && <div
+      <div
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -309,50 +309,32 @@ function AssessmentPanel({ assessment, meta, showHeader = true }: { assessment: 
           )}
         </div>
         <div className="cat-score-bar">
-          {lighthouseScore !== undefined ? (
+          {score !== undefined ? (
             <>
-              <div style={{ fontSize: '1rem', fontWeight: 600, color: meta.color }}>{lighthouseScore}%</div>
+              <div style={{ fontSize: '1rem', fontWeight: 600, color: meta.color }}>{score}%</div>
               <div className="bar-track">
-                <div className="bar-fill" style={{ width: `${lighthouseScore}%`, background: meta.color }} />
+                <div className="bar-fill" style={{ width: `${score}%`, background: meta.color }} />
               </div>
-              <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)' }}>Lighthouse score</div>
-            </>
-          ) : axeViolations !== undefined ? (
-            <>
-              <div style={{ fontSize: '1rem', fontWeight: 600, color: axeViolations === 0 ? 'var(--eaa-green)' : meta.color }}>
-                {axeViolations} issue{axeViolations !== 1 ? 's' : ''}
-              </div>
-              <div className="bar-track">
-                <div
-                  className="bar-fill"
-                  style={{
-                    width: axePasses !== undefined
-                      ? `${Math.round((axePasses / (axePasses + axeViolations)) * 100)}%`
-                      : `${pct}%`,
-                    background: meta.color,
-                  }}
-                />
-              </div>
-              {axePasses !== undefined && (
+              {subLabel ? (
+                <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)' }}>{subLabel}</div>
+              ) : axePasses !== undefined && axeViolations !== undefined ? (
                 <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)' }}>
                   {axePasses} pass · {axeViolations} fail
                 </div>
+              ) : (
+                <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)' }}>Score</div>
               )}
             </>
           ) : (
-            <>
-              <div style={{ fontSize: '1rem', fontWeight: 600, color: meta.color }}>{pct}%</div>
-              <div className="bar-track">
-                <div className="bar-fill" style={{ width: `${pct}%`, background: meta.color }} />
-              </div>
-              <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)' }}>{passed}/{total} checks</div>
-            </>
+            <div style={{ fontSize: '0.88rem', color: 'var(--text-dim)' }}>
+              {allCompleted ? 'No score' : 'Pending'}
+            </div>
           )}
         </div>
-      </div>}
+      </div>
 
-      {/* Sustainability / no findings */}
-      {assessment.status === 'completed' && allFindings.length === 0 && (
+      {/* No findings */}
+      {allCompleted && mergedFindings.length === 0 && (
         <div
           style={{
             background: 'var(--eaa-green-bg)',
@@ -366,35 +348,43 @@ function AssessmentPanel({ assessment, meta, showHeader = true }: { assessment: 
         >
           <span style={{ color: 'var(--eaa-green)', fontSize: '1.1rem' }}>✓</span>
           <div>
-            {typeof assessment.details?.message === 'string' ? (
-              <p style={{ fontSize: '0.88rem', color: 'var(--text-base)' }}>{assessment.details.message}</p>
-            ) : (
-              <p style={{ fontSize: '0.88rem', color: 'var(--eaa-green)' }}>No issues found.</p>
-            )}
-            {typeof assessment.details?.hosted_by === 'string' && (
-              <span
-                style={{
-                  fontSize: '0.75rem',
-                  background: 'var(--eaa-green-bg)',
-                  color: 'var(--eaa-green)',
-                  border: '1px solid rgba(61,214,140,0.3)',
-                  borderRadius: 100,
-                  padding: '2px 10px',
-                  display: 'inline-block',
-                  marginTop: 6,
-                }}
-              >
-                Hosted by {assessment.details.hosted_by}
-              </span>
-            )}
+            {/* Show message/hosted_by from any assessment that has them */}
+            {(() => {
+              const withMessage = assessments.find((a) => typeof a.details?.message === 'string');
+              return withMessage ? (
+                <>
+                  <p style={{ fontSize: '0.88rem', color: 'var(--text-base)' }}>
+                    {withMessage.details!.message as string}
+                  </p>
+                  {typeof withMessage.details?.hosted_by === 'string' && (
+                    <span
+                      style={{
+                        fontSize: '0.75rem',
+                        background: 'var(--eaa-green-bg)',
+                        color: 'var(--eaa-green)',
+                        border: '1px solid rgba(61,214,140,0.3)',
+                        borderRadius: 100,
+                        padding: '2px 10px',
+                        display: 'inline-block',
+                        marginTop: 6,
+                      }}
+                    >
+                      Hosted by {withMessage.details!.hosted_by as string}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <p style={{ fontSize: '0.88rem', color: 'var(--eaa-green)' }}>No issues found.</p>
+              );
+            })()}
           </div>
         </div>
       )}
 
       {/* Findings list */}
-      {allFindings.length > 0 && (
+      {mergedFindings.length > 0 && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {allFindings.map((f, i) => (
+          {mergedFindings.map((f, i) => (
             <FindingItem key={f.id} finding={f} defaultOpen={i === 0} />
           ))}
         </div>
@@ -404,7 +394,9 @@ function AssessmentPanel({ assessment, meta, showHeader = true }: { assessment: 
 }
 
 export function ChecklistView({ assessments }: ChecklistViewProps) {
-  const grouped = groupByCategory(assessments.filter((a) => a.status !== 'skipped'));
+  const grouped = groupByCategory(
+    assessments.filter((a) => a.status !== 'skipped' && a.identifier !== 'http-fetch'),
+  );
   const tabs = [...grouped.keys()];
   const [activeTab, setActiveTab] = useState(tabs[0] ?? '');
 
@@ -439,7 +431,7 @@ export function ChecklistView({ assessments }: ChecklistViewProps) {
         {tabs.map((key) => {
           const m = meta(key);
           const group = grouped.get(key)!;
-          const totalFindings = group.reduce((s, a) => s + a.findings.length, 0);
+          const totalFindings = mergeFindings(group).length;
           return (
             <button
               key={key}
@@ -448,7 +440,7 @@ export function ChecklistView({ assessments }: ChecklistViewProps) {
               style={{ width: '100%', justifyContent: 'center' }}
             >
               <span aria-hidden="true">{m.icon}</span>
-              {m.label.split('(')[0].trim()}
+              {m.label}
               {totalFindings > 0 && (
                 <span
                   style={{
@@ -468,17 +460,9 @@ export function ChecklistView({ assessments }: ChecklistViewProps) {
       </div>
 
       {/* Active panel */}
-      {tabs.filter((t) => t === activeTab).map((key) => {
-        const m = meta(key);
-        const group = grouped.get(key)!;
-        return (
-          <div key={key}>
-            {group.map((assessment, i) => (
-              <AssessmentPanel key={assessment.id} assessment={assessment} meta={m} showHeader={i === 0} />
-            ))}
-          </div>
-        );
-      })}
+      {tabs.filter((t) => t === activeTab).map((key) => (
+        <CategoryPanel key={key} assessments={grouped.get(key)!} meta={meta(key)} />
+      ))}
     </div>
   );
 }

--- a/src/components/ScanResults.tsx
+++ b/src/components/ScanResults.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import type { Assessment, Scan } from '../types/scanner';
 import { ScoreRing } from './ScoreRing';
 import { ChecklistView } from './ChecklistView';
+import { mergeFindings } from '../utils/findings';
 import html2pdf from 'html2pdf.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -33,34 +34,31 @@ function buildShareUrl(scanId: string): string {
 // ── Score calculations ────────────────────────────────────────────────────────
 
 function computeStats(assessments: Assessment[]) {
-  const relevant = assessments.filter((a) => a.status !== 'skipped');
+  const relevant = assessments.filter((a) => a.status !== 'skipped' && a.identifier !== 'http-fetch');
 
-  const allFindings = relevant.flatMap((a) => a.findings);
-  const criticalCount = allFindings.filter(
-    (f) => typeof f.details.impact === 'string' && f.details.impact === 'critical',
-  ).length;
-  const seriousCount = allFindings.filter(
-    (f) => typeof f.details.impact === 'string' && f.details.impact === 'serious',
-  ).length;
+  // Group by category, then deduplicate findings within each group
+  const byCategory = new Map<string, Assessment[]>();
+  for (const a of relevant) {
+    const key = a.category ?? a.identifier;
+    if (!byCategory.has(key)) byCategory.set(key, []);
+    byCategory.get(key)!.push(a);
+  }
+  const allFindings = [...byCategory.values()].flatMap(mergeFindings);
+
+  const criticalCount = allFindings.filter((f) => f.details.impact === 'critical').length;
+  const seriousCount  = allFindings.filter((f) => f.details.impact === 'serious').length;
   const totalFindings = allFindings.length;
 
-  // Best available overall score: prefer Lighthouse score_percent, fall back to Axe, then pass ratio
-  const lighthouseAssessment = relevant.find(
-    (a) => a.identifier === 'lighthouse' && typeof a.details?.score_percent === 'number',
-  );
-  const axeAssessment = relevant.find(
-    (a) => a.identifier === 'accessibility' && typeof a.details?.score_percent === 'number',
-  );
+  // Overall score: average of all score_percent values across assessments
+  const scores = relevant
+    .filter((a) => typeof a.details?.score_percent === 'number')
+    .map((a) => a.details!.score_percent as number);
 
-  let overallScore: number;
-  if (lighthouseAssessment && typeof lighthouseAssessment.details?.score_percent === 'number') {
-    overallScore = lighthouseAssessment.details.score_percent as number;
-  } else if (axeAssessment && typeof axeAssessment.details?.score_percent === 'number') {
-    overallScore = axeAssessment.details.score_percent as number;
-  } else {
-    const passed = relevant.filter((a) => a.findings.length === 0 && a.status === 'completed').length;
-    overallScore = relevant.length > 0 ? Math.round((passed / relevant.length) * 100) : 100;
-  }
+  const overallScore = scores.length > 0
+    ? Math.round(scores.reduce((s, n) => s + n, 0) / scores.length)
+    : relevant.length > 0
+      ? Math.round((relevant.filter((a) => a.findings.length === 0 && a.status === 'completed').length / relevant.length) * 100)
+      : 100;
 
   const categories = new Set(relevant.map((a) => a.category ?? a.identifier));
   const isCompliant = criticalCount === 0 && seriousCount === 0;

--- a/src/utils/findings.ts
+++ b/src/utils/findings.ts
@@ -1,0 +1,29 @@
+import type { Assessment, Finding } from '../types/scanner';
+
+/**
+ * Merges findings from multiple assessments in the same category, deduplicating
+ * by finding identifier. Axe findings are processed first because they carry
+ * richer data (impact, nodes, tags, help_url). Findings from other tools are
+ * appended only if their identifier hasn't already been seen.
+ */
+export function mergeFindings(assessments: Assessment[]): Finding[] {
+  const seen = new Map<string, Finding>();
+
+  // Axe first — has impact/nodes/tags/help_url
+  for (const a of assessments) {
+    if (a.identifier === 'axe') {
+      for (const f of a.findings) seen.set(f.identifier, f);
+    }
+  }
+
+  // All other assessments: only add identifiers not already present
+  for (const a of assessments) {
+    if (a.identifier !== 'axe') {
+      for (const f of a.findings) {
+        if (!seen.has(f.identifier)) seen.set(f.identifier, f);
+      }
+    }
+  }
+
+  return [...seen.values()];
+}


### PR DESCRIPTION
## Problem

When both axe and lighthouse run on the same category, the frontend showed overlapping findings twice (e.g. `color-contrast` appeared from both tools) and used only the lighthouse `score_percent` for the overall score ring — completely ignoring axe's score.

## Changes

**`src/utils/findings.ts`** (new)
- `mergeFindings(assessments)`: deduplicates findings by `identifier` across multiple assessments. Axe entries are preferred (they carry `impact`, `nodes`, `tags`, `help_url`). Lighthouse-only findings are appended.

**`src/components/ChecklistView.tsx`**
- Replaced `AssessmentPanel` (rendered one assessment at a time, causing lighthouse findings to appear with no header) with `CategoryPanel` (takes the full group, renders merged findings)
- `normalizedCategoryScore()`: averages `score_percent` across all completed assessments in the group
- `scoreSubLabel()`: shows "Axe: 84% · Lighthouse: 82%" when multiple scores are present
- Tab badge now reflects the deduplicated findings count
- `http-fetch` filtered out (internal no-op check, cluttered the tabs)

**`src/components/ScanResults.tsx`**
- `computeStats()` groups assessments by category, runs `mergeFindings` per group — critical/serious/total counts and the overall ring score are now based on deduplicated findings
- Overall score is the average of all `score_percent` values (no more lighthouse-only preference)

## Result (css-tricks.com example)

| Before | After |
|---|---|
| 15 total findings (4 duplicates) | 11 deduplicated findings |
| Overall score: 82% (lighthouse only) | Overall score: 83% (avg of 84% + 82%) |
| Lighthouse findings unlabeled | Single merged panel with sub-label |
| "Http Fetch" tab visible | Gone |

🤖 Generated with [Claude Code](https://claude.com/claude-code)